### PR TITLE
fix: migrate docs deployment to GitHub Actions Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,17 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -37,11 +44,22 @@ jobs:
         run: |
           uv sync --dev --prerelease=allow
 
-      - name: Configure Git
+      - name: Build documentation
         run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
+          uv run mkdocs build --clean --strict
 
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
-        run: |
-          uv run mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Overview
Migrates documentation deployment from `gh-pages` branch to modern GitHub Actions Pages deployment method.

## What Changed

### Old Method (gh-pages branch):
- Used `mkdocs gh-deploy` command
- Pushed to `gh-pages` branch
- Required `contents: write` permission
- Had to maintain separate branch

### New Method (GitHub Actions):
- Uses official `actions/upload-pages-artifact@v3`
- Uses official `actions/deploy-pages@v4`  
- Proper permissions: `pages: write`, `id-token: write`
- No separate `gh-pages` branch needed
- Separate build and deploy jobs
- Environment protection with `github-pages`

## Benefits

✅ **No gh-pages branch to maintain** - Cleaner git history
✅ **Better security** - Proper minimal permissions
✅ **Official GitHub Actions integration** - Recommended method
✅ **Automatic artifact management** - No manual cleanup
✅ **Environment protection** - Can add approval workflows

## Testing

After merge:
1. Enable GitHub Actions as Pages source in repo settings
2. Go to: https://github.com/niksacdev/loan-avengers/settings/pages
3. Under "Build and deployment": Source → Select **"GitHub Actions"**
4. Workflow will automatically deploy on merge
5. Visit: https://niksacdev.github.io/loan-avengers/

## References
- GitHub Actions Pages: https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages
- Article reference: https://til.simonwillison.net/github-actions/github-pages
- Related: ADR-016 (GitHub Actions Security Standards)

## Related
- Fixes GitHub Pages 404 issue
- Modernizes deployment workflow
- Follows best practices from ADR-016

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)